### PR TITLE
Baseline: differential dependency declaration

### DIFF
--- a/src/BaselineOfHierarchicalVisualizations/BaselineOfHierarchicalVisualizations.class.st
+++ b/src/BaselineOfHierarchicalVisualizations/BaselineOfHierarchicalVisualizations.class.st
@@ -11,11 +11,7 @@ Class {
 BaselineOfHierarchicalVisualizations >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ 
-		spec
-			baseline: 'Roassal3'
-			with: [ spec repository: 'github://ObjectProfile/Roassal3/src' ].
-		"Packages"
+	spec for: #common do: [ "Packages"
 		spec
 			package: 'Hierarchical-Model-Events';
 			package: 'Hierarchical-Model';
@@ -27,6 +23,9 @@ BaselineOfHierarchicalVisualizations >> baseline: spec [
 			package: 'Hierarchical-Roassal3-Tests'.
 
 		spec for: #( #'pharo8.x' #'pharo9.x' ) do: [ 
+			spec
+				baseline: 'Roassal3'
+				with: [ spec repository: 'github://ObjectProfile/Roassal3/src' ].
 			spec
 				package: 'Hierarchical-Model'
 				with: [ spec requires: 'Roassal3' ] ].

--- a/src/BaselineOfHierarchicalVisualizations/BaselineOfHierarchicalVisualizations.class.st
+++ b/src/BaselineOfHierarchicalVisualizations/BaselineOfHierarchicalVisualizations.class.st
@@ -9,13 +9,16 @@ Class {
 
 { #category : #baselines }
 BaselineOfHierarchicalVisualizations >> baseline: spec [
+
 	<baseline>
 	spec for: #common do: [ 
-		spec baseline: 'Roassal3' with: [ spec repository: 'github://ObjectProfile/Roassal3/src' ].
+		spec
+			baseline: 'Roassal3'
+			with: [ spec repository: 'github://ObjectProfile/Roassal3/src' ].
 		"Packages"
 		spec
 			package: 'Hierarchical-Model-Events';
-			package: 'Hierarchical-Model' with: [ spec requires: 'Roassal3' ];
+			package: 'Hierarchical-Model';
 			package: 'Hierarchical-Model-Tests';
 			package: 'Hierarchical-Builder';
 			package: 'Hierarchical-Roassal3';
@@ -23,17 +26,18 @@ BaselineOfHierarchicalVisualizations >> baseline: spec [
 			package: 'Hierarchical-Examples';
 			package: 'Hierarchical-Roassal3-Tests'.
 
+		spec for: #( #'pharo8.x' #'pharo9.x' ) do: [ 
+			spec
+				package: 'Hierarchical-Model'
+				with: [ spec requires: 'Roassal3' ] ].
+
 		"Groups"
 		spec
-			group: 'Core' with: #(
-				'Hierarchical-Model-Events'
-				'Hierarchical-Model'
-				'Hierarchical-Model-Tests'
-				'Hierarchical-Builder');
-			group: 'default' with: #(
-				'Core'
-				'Hierarchical-Roassal3'
-				'Hierarchical-Roassal3-Menu'
-				'Hierarchical-Roassal3-Tests'
-				'Hierarchical-Examples' ) ]
+			group: 'Core'
+			with: #( 'Hierarchical-Model-Events' 'Hierarchical-Model'
+				   'Hierarchical-Model-Tests' 'Hierarchical-Builder' );
+			group: 'default'
+			with:
+				#( 'Core' 'Hierarchical-Roassal3' 'Hierarchical-Roassal3-Menu'
+				   'Hierarchical-Roassal3-Tests' 'Hierarchical-Examples' ) ]
 ]


### PR DESCRIPTION
Declare dependency to Roassal 3 only pharo pharo 8 and 9, as the Pharo 10 version of Roassal is compatible with HV.

Allows us to remove MergeOrLoadWarning management from baseline in dependent projects.